### PR TITLE
CLI Policy Check enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/centrifuge_cli/main.py
+++ b/centrifuge_cli/main.py
@@ -393,9 +393,10 @@ def binary_hardening(cli):
 
 @report.command(name='check-policy')
 @click.option('--policy-yaml', metavar='FILE', type=click.Path(), help='Centrifuge policy yaml file.', required=True)
+@click.option('--verbose', help='Details on policy evaluation.', is_flag=True)
 @click.pass_context
 @pass_cli
-def check_policy(cli, ctx, policy_yaml):
+def check_policy(cli, ctx, policy_yaml, verbose=False):
     outfmt = cli.outfmt
     cli.outfmt = 'json'
     cli.echo_enabled = False
@@ -412,7 +413,8 @@ def check_policy(cli, ctx, policy_yaml):
                                        binary_hardening_json,
                                        guardian_json,
                                        code_summary_json,
-                                       passhash_json)
+                                       passhash_json,
+                                       verbose)
 
     policy_obj.check_rules(policy_yaml)
 

--- a/centrifuge_cli/main.py
+++ b/centrifuge_cli/main.py
@@ -393,10 +393,11 @@ def binary_hardening(cli):
 
 @report.command(name='check-policy')
 @click.option('--policy-yaml', metavar='FILE', type=click.Path(), help='Centrifuge policy yaml file.', required=True)
+@click.option('--explain', help='Add reasons for failure to results', is_flag=True)
 @click.option('--verbose', help='Details on policy evaluation.', is_flag=True)
 @click.pass_context
 @pass_cli
-def check_policy(cli, ctx, policy_yaml, verbose=False):
+def check_policy(cli, ctx, policy_yaml, explain=False, verbose=False):
     outfmt = cli.outfmt
     cli.outfmt = 'json'
     cli.echo_enabled = False
@@ -414,13 +415,15 @@ def check_policy(cli, ctx, policy_yaml, verbose=False):
                                        guardian_json,
                                        code_summary_json,
                                        passhash_json,
+                                       explain,
                                        verbose)
 
     policy_obj.check_rules(policy_yaml)
 
-    result = policy_obj.generate_csv()
     if outfmt == 'json':
         result = policy_obj.generate_json()
+    else:
+        result = policy_obj.generate_csv()
 
     cli.echo_enabled = True
     cli.outfmt = outfmt

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -241,18 +241,20 @@ class CentrifugePolicyCheck(object):
 
     def checkPasswordHashRule(self, value):
         self.verboseprint("Checking Password Hash Rule...")
-        count = 0
+        rule_passed = True
         json_data = self.passhash_json
         if json_data.get("count") > 0:
+            if not value.get("allowUserAccounts", True):
+                self.verboseprint(f'...failing allowUserAccounts - identified {json_data.get("count")} accounts')
+                rule_passed = False
             for hash_obj in json_data.get("results"):
                 if hash_obj.get("algorithm") in value.get("weakAlgorithms", []):
-                    count += 1
-            if count > 0:
-                return "Fail"
-            else:
-                return "Pass"
-        else:
+                    self.verboseprint(f'...failing weakAlgorithms {hash_obj["algorithm"]} for user {hash_obj["username"]}')
+                    rule_passed = False
+        if rule_passed:
             return "Pass"
+        else:
+            return "Fail"
 
     def call_policy_method(self, policy_name, ruledef):
         policy_method = getattr(self, POLICY_DETAIL_MAPPING.get(policy_name).get("method"))

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -257,22 +257,7 @@ class CentrifugePolicyCheck(object):
         Method which calls the respective rule checking function for rule name and populates the
         compliant of policy.
         """
-        if name == 'privateKeys':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'certificates':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'passwordHashes':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'code':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'guardian':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'binaryHardening':
+        if name in POLICY_DETAIL_MAPPING:
             policy_status = self.call_policy_method(name, ruledef)
             POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
         else:
@@ -282,7 +267,7 @@ class CentrifugePolicyCheck(object):
         output = io.StringIO()
         writer = csv.DictWriter(output, fieldnames=CSV_HEADER)
         writer.writeheader()
-        for policy, policy_detail in POLICY_DETAIL_MAPPING.items():
+        for _, policy_detail in POLICY_DETAIL_MAPPING.items():
             writer.writerow({"Policy Name": policy_detail.get("name"), "Compliant": policy_detail.get("status")})
         return output.getvalue()
 
@@ -307,7 +292,7 @@ class CentrifugePolicyCheck(object):
         with open(config_file, 'r') as stream:
             try:
                 res = yaml.safe_load(stream)
-                for i, rule in enumerate(POLICIES):
+                for _, rule in enumerate(POLICY_DETAIL_MAPPING):
                     if rule in res['rules']:
                         self.checkRule(rule, res['rules'][rule])
                     else:

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -28,11 +28,11 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
-```
 
-Other command options:
-```--verbose``` : outputs details on compliance check logic
-```--explain``` : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
+# Other command options:
+--explain : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
+--verbose : outputs details on compliance check logic
+```
 
 ## Policy Rule Definition
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -7,6 +7,7 @@ This command line tool takes a policy file that defines the policy rules that yo
 ## Prerequisites
 
 Before you begin, ensure you have met the following requirements:
+
 * You have python 3 installed (tested with python 3.7)
 * You have an active Centrifuge account with a valid API authtoken
 * You have a completed Centrifuge report that you wish to check
@@ -27,11 +28,11 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
-
-# Check your policy against Centrifuge report 1234 and output json format with details on policy checks
-centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --verbose
 ```
 
+Other command options:
+```--verbose``` : outputs details on compliance check logic
+```--explain``` : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
 
 ## Policy Rule Definition
 
@@ -49,7 +50,7 @@ Current policy schema version: `1.0`
 
 Refer to example rule definition files included in this repository for more examples.
 
-#### Rule exceptions
+### Rule exceptions
 
 You may only want to apply a rule to a certain set of files rather than all the files in the firmware image, or apply the rule to all files except a certain set of files you wish to ignore. Many (if not all) of the rules can be defined in this way for maximum flexibility.
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -27,6 +27,9 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
+
+# Check your policy against Centrifuge report 1234 and output json format with details on policy checks
+centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --verbose
 ```
 
 
@@ -111,24 +114,39 @@ Firmware images containing any password hashes with the algorithms defined below
 ### Rule: Code Flaws
 
 Firmware images containing any high risk executables with code flaws will fail this policy check.
-Set `allowed: false` to check against all files (except those omitted in the `exceptions` modifier.
-Set `allowed: true` along with `exceptions` in order to only check a specific list of files for code flaws.
+Set `allowed: false` to check against all files (except those omitted in the `exceptions` modifier).
+Set `allowCritical: false` to check for only critical (emulated) flaws (except those omitted in the `exceptions` modifier)
 ```
   code:
     flaws:
+      # allow any potential flaws
       allowed: true
-    # the policy check will fail if any of the following files contain code flaws
+
+      # allow critical (emulated) flaws
+      allowCritical: false
+
+    # optional list of files that are omitted from this rule
     exceptions:
       - /usr/local/bin/*
       - /opt/vendor/*
 ```
 
-### Rule: CVE Threshold
+### Rule: Guardian
 
-Firmware images containing any CVEs with a CVSS rating at or above the given threshold will fail the policy check.
+Firmware images containing any CVEs with a CVSS rating at or above the given threshold or age will fail the policy check.
+Use exceptions to exclude specific files from the policy check
 ```
   guardian:
-    cvssScoreThreshold: 9.0
+    # any CVEs found at or above this threshold will cause the policy check to fail
+    cvssScoreThreshold: 7.0
+
+    # any CVEs from this year or older will cause the policy check to fail
+    # either put year (i.e., 2017) or # years (i.e., 2 would fail 2018 or earlier CVEs in 2020)
+    cveAgeThreshold: 2
+
+    # optional list of files that are omitted from this rule
+    exceptions:
+      - cpio-root/bin/busybox
 ```
 
 ### Rule: Binary Hardness

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -104,8 +104,13 @@ Firmware images containing any private keys will fail this policy check.
 ### Rule: Weak Password Hashes
 
 Firmware images containing any password hashes with the algorithms defined below will fail.
+Set `allowUserAccounts: false` to fail if any user accounts are present, regardless of hash algorithm.
 ```
   passwordHashes:
+    # whether defined user accounts are allowed or not
+    allowUserAccounts: true
+
+    # any hashes with the following algorithms will fail the policy check
     weakAlgorithms:
       - des
       - md5

--- a/docs/example-policy-lenient.yml
+++ b/docs/example-policy-lenient.yml
@@ -4,6 +4,7 @@ rules:
     expired:
       allowed: true
   passwordHashes:
+    allowUserAccounts: true
     weakAlgorithms: [des, md5]
   privateKeys:
     allowed: true

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -66,5 +66,6 @@ rules:
     # optional whitelist of binaries to check for above features.
     # if omitted, all binaries will be checked
     include:
+      - /kernel/drivers/*
       - /opt/vendor/*
       - /root/*

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -31,14 +31,27 @@ rules:
 
   code:
     flaws:
-      allowed: false
+      # allow any potential flaws
+      allowed: true
+
+      # allow critical (emulated) flaws
+      allowCritical: false
+      
     # optional list of files that are omitted from this rule
     exceptions:
-     - /opt/vendor/*
+      - /opt/vendor/*
 
   guardian:
     # any CVEs found at or above this threshold will cause the policy check to fail
-    cvssScoreThreshold: 9.0
+    cvssScoreThreshold: 7.0
+
+    # any CVEs from this year or older will cause the policy check to fail
+    # either put year (i.e., 2017) or # years (i.e., 2 would fail 2018 or earlier CVEs in 2020)
+    cveAgeThreshold: 2
+
+    # optional list of files that are omitted from this rule
+    exceptions:
+      - cpio-root/bin/busybox
 
   binaryHardening:
     # a list of hardening features required for ELF binaries

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -24,6 +24,9 @@ rules:
       - /usr/*
 
   passwordHashes:
+    # whether defined user accounts are allowed or not
+    allowUserAccounts: false
+
     # any hashes with the following algorithms will fail the policy check
     weakAlgorithms:
       - des
@@ -36,7 +39,7 @@ rules:
 
       # allow critical (emulated) flaws
       allowCritical: false
-      
+
     # optional list of files that are omitted from this rule
     exceptions:
       - /opt/vendor/*


### PR DESCRIPTION
Enhancements to policy check in centrifuge-cli:

- Code Flaws has new filter for just failing on critical emulated flaws
- Guardian adds new check for CVE age, as well as allowing exceptions
- Passwords adds compliance option for presence of user accounts
- Fixed bugs in exception handling for private keys, certificates and binary hardening
- Added optional output of detailed reasons for compliance failure
- Added optional mode for verbose output on compliance checks
- General code cleanup

Happy to merge into one set after review if required.