### PR TITLE
Policy Check enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/centrifuge_cli/main.py
+++ b/centrifuge_cli/main.py
@@ -393,9 +393,10 @@ def binary_hardening(cli):
 
 @report.command(name='check-policy')
 @click.option('--policy-yaml', metavar='FILE', type=click.Path(), help='Centrifuge policy yaml file.', required=True)
+@click.option('--verbose', help='Details on policy evaluation.', is_flag=True)
 @click.pass_context
 @pass_cli
-def check_policy(cli, ctx, policy_yaml):
+def check_policy(cli, ctx, policy_yaml, verbose=False):
     outfmt = cli.outfmt
     cli.outfmt = 'json'
     cli.echo_enabled = False
@@ -412,7 +413,8 @@ def check_policy(cli, ctx, policy_yaml):
                                        binary_hardening_json,
                                        guardian_json,
                                        code_summary_json,
-                                       passhash_json)
+                                       passhash_json,
+                                       verbose)
 
     policy_obj.check_rules(policy_yaml)
 

--- a/centrifuge_cli/main.py
+++ b/centrifuge_cli/main.py
@@ -394,11 +394,9 @@ def binary_hardening(cli):
 @report.command(name='check-policy')
 @click.option('--policy-yaml', metavar='FILE', type=click.Path(), help='Centrifuge policy yaml file.', required=True)
 @click.option('--report-template', metavar='FILE', type=click.Path(), help='Policy report template file.', required=False)
-@click.option('--explain', help='Add reasons for failure to results', is_flag=True)
-@click.option('--verbose', help='Details on policy evaluation.', is_flag=True)
 @click.pass_context
 @pass_cli
-def check_policy(cli, ctx, policy_yaml, report_template, explain=False, verbose=False):
+def check_policy(cli, ctx, policy_yaml, report_template):
     outfmt = cli.outfmt
     cli.outfmt = 'json'
     cli.echo_enabled = False
@@ -417,9 +415,7 @@ def check_policy(cli, ctx, policy_yaml, report_template, explain=False, verbose=
                                        guardian_json,
                                        code_summary_json,
                                        passhash_json,
-                                       info_json,
-                                       explain,
-                                       verbose)
+                                       info_json)
 
     policy_obj.check_rules(policy_yaml)
 

--- a/centrifuge_cli/main.py
+++ b/centrifuge_cli/main.py
@@ -393,11 +393,12 @@ def binary_hardening(cli):
 
 @report.command(name='check-policy')
 @click.option('--policy-yaml', metavar='FILE', type=click.Path(), help='Centrifuge policy yaml file.', required=True)
+@click.option('--report-template', metavar='FILE', type=click.Path(), help='Policy report template file.', required=False)
 @click.option('--explain', help='Add reasons for failure to results', is_flag=True)
 @click.option('--verbose', help='Details on policy evaluation.', is_flag=True)
 @click.pass_context
 @pass_cli
-def check_policy(cli, ctx, policy_yaml, explain=False, verbose=False):
+def check_policy(cli, ctx, policy_yaml, report_template, explain=False, verbose=False):
     outfmt = cli.outfmt
     cli.outfmt = 'json'
     cli.echo_enabled = False
@@ -408,6 +409,7 @@ def check_policy(cli, ctx, policy_yaml, explain=False, verbose=False):
     guardian_json = json.loads(ctx.invoke(guardian))
     code_summary_json = json.loads(ctx.invoke(code_summary))
     passhash_json = json.loads(ctx.invoke(passhash))
+    info_json = json.loads(ctx.invoke(info))
 
     policy_obj = CentrifugePolicyCheck(certificates_json,
                                        private_keys_json,
@@ -415,12 +417,15 @@ def check_policy(cli, ctx, policy_yaml, explain=False, verbose=False):
                                        guardian_json,
                                        code_summary_json,
                                        passhash_json,
+                                       info_json,
                                        explain,
                                        verbose)
 
     policy_obj.check_rules(policy_yaml)
 
-    if outfmt == 'json':
+    if report_template:
+        result = policy_obj.generate_report(report_template)
+    elif outfmt == 'json':
         result = policy_obj.generate_json()
     else:
         result = policy_obj.generate_csv()

--- a/centrifuge_cli/main.py
+++ b/centrifuge_cli/main.py
@@ -393,10 +393,11 @@ def binary_hardening(cli):
 
 @report.command(name='check-policy')
 @click.option('--policy-yaml', metavar='FILE', type=click.Path(), help='Centrifuge policy yaml file.', required=True)
+@click.option('--explain', help='Add reasons for failure to results', is_flag=True)
 @click.option('--verbose', help='Details on policy evaluation.', is_flag=True)
 @click.pass_context
 @pass_cli
-def check_policy(cli, ctx, policy_yaml, verbose=False):
+def check_policy(cli, ctx, policy_yaml, explain=False, verbose=False):
     outfmt = cli.outfmt
     cli.outfmt = 'json'
     cli.echo_enabled = False
@@ -414,13 +415,15 @@ def check_policy(cli, ctx, policy_yaml, verbose=False):
                                        guardian_json,
                                        code_summary_json,
                                        passhash_json,
+                                       explain,
                                        verbose)
 
     policy_obj.check_rules(policy_yaml)
 
-    result = policy_obj.generate_csv()
     if outfmt == 'json':
         result = policy_obj.generate_json()
+    else:
+        result = policy_obj.generate_csv()
 
     cli.echo_enabled = True
     cli.outfmt = outfmt

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -16,37 +16,37 @@ POLICY_DETAIL_MAPPING = {
         "name": "Expired Certificates",
         "method": "checkCertificateRule",
         "status": "Fail",
-        "reaons": []
+        "reasons": []
     },
     "privateKeys": {
         "name": "Private Keys",
         "method": "checkPrivateKeyRule",
         "status": "Fail",
-        "reaons": []
+        "reasons": []
     },
     "passwordHashes": {
         "name": "Weak Password Algorithms",
         "method": "checkPasswordHashRule",
         "status": "Fail",
-        "reaons": []
+        "reasons": []
     },
     "code": {
         "name": "Code Flaws",
         "method": "checkCodeFlawsRule",
         "status": "Fail",
-        "reaons": []
+        "reasons": []
     },
     "guardian": {
         "name": "CVE Threshold",
         "method": "checkGuardianRule",
         "status": "Fail",
-        "reaons": []
+        "reasons": []
     },
     "binaryHardening": {
         "name": "Binary Hardness",
         "method": "checkBinaryHardeningRule",
         "status": "Fail",
-        "reaons": []
+        "reasons": []
     }
 }
 POLICIES = [

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -59,6 +59,7 @@ POLICIES = [
     'binaryHardening'
 ]
 
+
 class CentrifugePolicyCheck(object):
     """
     A class to process POLICIES specified in YAML file.
@@ -150,7 +151,7 @@ class CentrifugePolicyCheck(object):
                             reason = f'private key found at {path}'
                             reasons.append(reason)
                             self.verboseprint(f'...failing: {reason}')
-        return rule_passed, reasons       
+        return rule_passed, reasons
 
     def check_files_for_binary_hardening(self, obj, value):
         boolean_feature = ("nx", "canary", "pie", "stripped")
@@ -323,7 +324,7 @@ class CentrifugePolicyCheck(object):
     def generate_json(self):
         json_results = self.build_json()
         return json.dumps(json_results, indent=2, sort_keys=True)
-    
+
     def generate_report(self, report_template):
         json_results = self.build_json()
         with open(report_template, 'r') as f:

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -71,9 +71,7 @@ class CentrifugePolicyCheck(object):
                  guardian_json,
                  code_summary_json,
                  passhash_json,
-                 info_json,
-                 explain,
-                 verbose):
+                 info_json):
         self.certificates_json = certificates_json
         self.private_keys_json = private_keys_json
         self.binary_hardening_json = binary_hardening_json
@@ -81,8 +79,7 @@ class CentrifugePolicyCheck(object):
         self.code_summary_json = code_summary_json
         self.passhash_json = passhash_json
         self.info_json = info_json
-        self.explain = explain
-        self.verbose = verbose
+        self.verbose = False    # set to True to generate debug logging
 
     def verboseprint(self, *args):
         """
@@ -285,14 +282,12 @@ class CentrifugePolicyCheck(object):
     def generate_csv(self):
         output = io.StringIO()
         field_names = CSV_HEADER
-        if self.explain:
-            field_names.append("Reasons")
+        field_names.append("Reasons")
         writer = csv.DictWriter(output, fieldnames=field_names)
         writer.writeheader()
         for _, policy_detail in POLICY_DETAIL_MAPPING.items():
             row_data = {"Policy Name": policy_detail.get("name"), "Compliant": policy_detail.get("status")}
-            if self.explain:
-                row_data.update({"Reasons": policy_detail.get("reasons")})
+            row_data.update({"Reasons": policy_detail.get("reasons")})
             writer.writerow(row_data)
         return output.getvalue()
 
@@ -316,8 +311,7 @@ class CentrifugePolicyCheck(object):
                 "name": policy_detail.get("name"),
                 "compliant": policy_detail.get("status")
             }
-            if self.explain:
-                final_result.update({"reasons": policy_detail.get("reasons")})
+            final_result.update({"reasons": policy_detail.get("reasons")})
             final_result_dict.get("results").append(final_result)
         return final_result_dict
 

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -241,18 +241,20 @@ class CentrifugePolicyCheck(object):
 
     def checkPasswordHashRule(self, value):
         self.verboseprint("Checking Password Hash Rule...")
-        count = 0
+        rule_passed = True
         json_data = self.passhash_json
         if json_data.get("count") > 0:
+            if not value.get("allowUserAccounts", True):
+                self.verboseprint(f'...failing allowUserAccounts - identified {json_data.get("count")} accounts')
+                rule_passed = False
             for hash_obj in json_data.get("results"):
                 if hash_obj.get("algorithm") in value.get("weakAlgorithms", []):
-                    count += 1
-            if count > 0:
-                return "Fail"
-            else:
-                return "Pass"
-        else:
+                    self.verboseprint(f'...failing weakAlgorithms {hash_obj["algorithm"]} for user {hash_obj["username"]}')
+                    rule_passed = False
+        if rule_passed:
             return "Pass"
+        else:
+            return "Fail"
 
     def call_policy_method(self, policy_name, ruledef):
         policy_method = getattr(self, POLICY_DETAIL_MAPPING.get(policy_name).get("method"))

--- a/centrifuge_cli/policy.py
+++ b/centrifuge_cli/policy.py
@@ -257,22 +257,7 @@ class CentrifugePolicyCheck(object):
         Method which calls the respective rule checking function for rule name and populates the
         compliant of policy.
         """
-        if name == 'privateKeys':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'certificates':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'passwordHashes':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'code':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'guardian':
-            policy_status = self.call_policy_method(name, ruledef)
-            POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
-        elif name == 'binaryHardening':
+        if name in POLICY_DETAIL_MAPPING:
             policy_status = self.call_policy_method(name, ruledef)
             POLICY_DETAIL_MAPPING.get(name).update({"status": policy_status})
         else:
@@ -282,7 +267,7 @@ class CentrifugePolicyCheck(object):
         output = io.StringIO()
         writer = csv.DictWriter(output, fieldnames=CSV_HEADER)
         writer.writeheader()
-        for policy, policy_detail in POLICY_DETAIL_MAPPING.items():
+        for _, policy_detail in POLICY_DETAIL_MAPPING.items():
             writer.writerow({"Policy Name": policy_detail.get("name"), "Compliant": policy_detail.get("status")})
         return output.getvalue()
 
@@ -307,7 +292,7 @@ class CentrifugePolicyCheck(object):
         with open(config_file, 'r') as stream:
             try:
                 res = yaml.safe_load(stream)
-                for i, rule in enumerate(POLICIES):
+                for _, rule in enumerate(POLICY_DETAIL_MAPPING):
                     if rule in res['rules']:
                         self.checkRule(rule, res['rules'][rule])
                     else:

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -28,11 +28,11 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
-```
 
-Other command options:
-```--verbose``` : outputs details on compliance check logic
-```--explain``` : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
+# Other command options:
+--explain : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
+--verbose : outputs details on compliance check logic
+```
 
 ## Policy Rule Definition
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -25,8 +25,6 @@ pip3 install centrifuge-cli
 ```
 # Command options:
 --policy-yaml : location of policy rules file (see below)
---explain : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
---verbose : outputs details on compliance check logic
 --report-template : location of mustache-based template for compliance report
 
 # Check your policy against Centrifuge report 1234 and output CSV format (default)
@@ -36,7 +34,7 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output full html compliance report using example template
-centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --explain --report-template example-policy-report.mustache > compliance_report.htm
+centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --report-template example-policy-report.mustache > compliance_report.htm
 ```
 
 ## Policy Rule Definition

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -7,6 +7,7 @@ This command line tool takes a policy file that defines the policy rules that yo
 ## Prerequisites
 
 Before you begin, ensure you have met the following requirements:
+
 * You have python 3 installed (tested with python 3.7)
 * You have an active Centrifuge account with a valid API authtoken
 * You have a completed Centrifuge report that you wish to check
@@ -27,11 +28,11 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
-
-# Check your policy against Centrifuge report 1234 and output json format with details on policy checks
-centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --verbose
 ```
 
+Other command options:
+```--verbose``` : outputs details on compliance check logic
+```--explain``` : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
 
 ## Policy Rule Definition
 
@@ -49,7 +50,7 @@ Current policy schema version: `1.0`
 
 Refer to example rule definition files included in this repository for more examples.
 
-#### Rule exceptions
+### Rule exceptions
 
 You may only want to apply a rule to a certain set of files rather than all the files in the firmware image, or apply the rule to all files except a certain set of files you wish to ignore. Many (if not all) of the rules can be defined in this way for maximum flexibility.
 

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -27,6 +27,9 @@ centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
+
+# Check your policy against Centrifuge report 1234 and output json format with details on policy checks
+centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --verbose
 ```
 
 
@@ -111,24 +114,39 @@ Firmware images containing any password hashes with the algorithms defined below
 ### Rule: Code Flaws
 
 Firmware images containing any high risk executables with code flaws will fail this policy check.
-Set `allowed: false` to check against all files (except those omitted in the `exceptions` modifier.
-Set `allowed: true` along with `exceptions` in order to only check a specific list of files for code flaws.
+Set `allowed: false` to check against all files (except those omitted in the `exceptions` modifier).
+Set `allowCritical: false` to check for only critical (emulated) flaws (except those omitted in the `exceptions` modifier)
 ```
   code:
     flaws:
+      # allow any potential flaws
       allowed: true
-    # the policy check will fail if any of the following files contain code flaws
+
+      # allow critical (emulated) flaws
+      allowCritical: false
+
+    # optional list of files that are omitted from this rule
     exceptions:
       - /usr/local/bin/*
       - /opt/vendor/*
 ```
 
-### Rule: CVE Threshold
+### Rule: Guardian
 
-Firmware images containing any CVEs with a CVSS rating at or above the given threshold will fail the policy check.
+Firmware images containing any CVEs with a CVSS rating at or above the given threshold or age will fail the policy check.
+Use exceptions to exclude specific files from the policy check
 ```
   guardian:
-    cvssScoreThreshold: 9.0
+    # any CVEs found at or above this threshold will cause the policy check to fail
+    cvssScoreThreshold: 7.0
+
+    # any CVEs from this year or older will cause the policy check to fail
+    # either put year (i.e., 2017) or # years (i.e., 2 would fail 2018 or earlier CVEs in 2020)
+    cveAgeThreshold: 2
+
+    # optional list of files that are omitted from this rule
+    exceptions:
+      - cpio-root/bin/busybox
 ```
 
 ### Rule: Binary Hardness

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -104,8 +104,13 @@ Firmware images containing any private keys will fail this policy check.
 ### Rule: Weak Password Hashes
 
 Firmware images containing any password hashes with the algorithms defined below will fail.
+Set `allowUserAccounts: false` to fail if any user accounts are present, regardless of hash algorithm.
 ```
   passwordHashes:
+    # whether defined user accounts are allowed or not
+    allowUserAccounts: true
+
+    # any hashes with the following algorithms will fail the policy check
     weakAlgorithms:
       - des
       - md5

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -23,15 +23,20 @@ pip3 install centrifuge-cli
 ## Using centrifuge-policy-check.py
 
 ```
+# Command options:
+--policy-yaml : location of policy rules file (see below)
+--explain : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
+--verbose : outputs details on compliance check logic
+--report-template : location of mustache-based template for compliance report
+
 # Check your policy against Centrifuge report 1234 and output CSV format (default)
 centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
 # Check your policy against Centrifuge report 1234 and output json format
 centrifuge --outfmt json report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml
 
-# Other command options:
---explain : adds "reasons" column to all reports which explains why policy failed / what needs to be fixed
---verbose : outputs details on compliance check logic
+# Check your policy against Centrifuge report 1234 and output full html compliance report using example template
+centrifuge report --ufid=<REPORT ID> check-policy --policy-yaml my-policy.yml --explain --report-template example-policy-report.mustache > compliance_report.htm
 ```
 
 ## Policy Rule Definition

--- a/docs/example-policy-lenient.yml
+++ b/docs/example-policy-lenient.yml
@@ -4,6 +4,7 @@ rules:
     expired:
       allowed: true
   passwordHashes:
+    allowUserAccounts: true
     weakAlgorithms: [des, md5]
   privateKeys:
     allowed: true

--- a/docs/example-policy-report.mustache
+++ b/docs/example-policy-report.mustache
@@ -1,0 +1,25 @@
+<style>
+  #Pass {
+    color:green;
+  }
+  #Fail {
+    color:red;
+  }
+</style>
+<h1>Centrifuge Policy Report</h1>
+<b>Vendor: </b>{{info.vendor}}<br/>
+<b>Device: </b>{{info.device}}<br/>
+<b>Version: </b>{{info.version}}<br/>
+
+<h2>Overall: <span id="{{finalResult}}">{{finalResult}}</span></h2>
+
+<ul>{{#results}}
+<li><h3>{{name}} : <span id="{{compliant}}">{{compliant}}</span></h3>
+  <ul>
+    {{#reasons}}
+      <li>{{.}}</li>
+    {{/reasons}}
+    <br/>
+  </ul>
+</li>
+{{/results}}</ul>

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -66,5 +66,6 @@ rules:
     # optional whitelist of binaries to check for above features.
     # if omitted, all binaries will be checked
     include:
+      - /kernel/drivers/*
       - /opt/vendor/*
       - /root/*

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -31,14 +31,27 @@ rules:
 
   code:
     flaws:
-      allowed: false
+      # allow any potential flaws
+      allowed: true
+
+      # allow critical (emulated) flaws
+      allowCritical: false
+      
     # optional list of files that are omitted from this rule
     exceptions:
-     - /opt/vendor/*
+      - /opt/vendor/*
 
   guardian:
     # any CVEs found at or above this threshold will cause the policy check to fail
-    cvssScoreThreshold: 9.0
+    cvssScoreThreshold: 7.0
+
+    # any CVEs from this year or older will cause the policy check to fail
+    # either put year (i.e., 2017) or # years (i.e., 2 would fail 2018 or earlier CVEs in 2020)
+    cveAgeThreshold: 2
+
+    # optional list of files that are omitted from this rule
+    exceptions:
+      - cpio-root/bin/busybox
 
   binaryHardening:
     # a list of hardening features required for ELF binaries

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -66,6 +66,6 @@ rules:
     # optional whitelist of binaries to check for above features.
     # if omitted, all binaries will be checked
     include:
-      - /kernel/drivers/*
+      - /lib/modules/*
       - /opt/vendor/*
       - /root/*

--- a/docs/example-policy.yml
+++ b/docs/example-policy.yml
@@ -24,6 +24,9 @@ rules:
       - /usr/*
 
   passwordHashes:
+    # whether defined user accounts are allowed or not
+    allowUserAccounts: false
+
     # any hashes with the following algorithms will fail the policy check
     weakAlgorithms:
       - des
@@ -36,7 +39,7 @@ rules:
 
       # allow critical (emulated) flaws
       allowCritical: false
-      
+
     # optional list of files that are omitted from this rule
     exceptions:
       - /opt/vendor/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pandas = "^0.25.1"
 dateparser = "^0.7.2"
 toml = "^0.10.0"
 pyyaml = "^5.3.1"
+chevron = "^0.13.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"


### PR DESCRIPTION
Enhancements to policy check in centrifuge-cli:

- Code Flaws has new filter for just failing on critical emulated flaws
- Guardian adds new check for CVE age, as well as allowing exceptions
- Passwords adds compliance option for presence of user accounts
- Fixed bugs in exception handling for private keys, certificates and binary hardening
- Added optional output of detailed reasons for compliance failure
- Added optional mode for verbose output on compliance checks
- General code cleanup

Happy to merge into one set after review if required.